### PR TITLE
remove bootstrapping facade with the alias loader

### DIFF
--- a/src/DocusignLumenServiceProvider.php
+++ b/src/DocusignLumenServiceProvider.php
@@ -15,9 +15,6 @@ class DocusignLumenServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->configure('docusign');
-
-        $loader = \Illuminate\Foundation\AliasLoader::getInstance();
-        $loader->alias('Docusign', \Tjphippen\Docusign\Facades\Docusign::class);
     }
 
     public function register()


### PR DESCRIPTION
Facade bootstrapping now depends on the `class_alias` for lumen, and the user can register the Facade manually in laravel.
